### PR TITLE
fix: Pipeline 1000 setting up

### DIFF
--- a/workshop/content/30-python/70-advanced-topics/200-pipelines/1000-setting-up.md
+++ b/workshop/content/30-python/70-advanced-topics/200-pipelines/1000-setting-up.md
@@ -16,7 +16,6 @@ from constructs import Construct
 from aws_cdk import (
     Stack
 )
-from pipeline_stage import WorkshopPipelineStage
 
 class WorkshopPipelineStack(Stack):
 

--- a/workshop/content/30-python/70-advanced-topics/200-pipelines/1000-setting-up.md
+++ b/workshop/content/30-python/70-advanced-topics/200-pipelines/1000-setting-up.md
@@ -16,7 +16,7 @@ from constructs import Construct
 from aws_cdk import (
     Stack
 )
-
+#from pipeline_stage import WorkshopPipelineStage
 class WorkshopPipelineStack(Stack):
 
     def __init__(self, scope: Construct, id: str, **kwargs) -> None:


### PR DESCRIPTION
<!--
Explain what changed and why.

Please read the [Contribution guidelines][1] and follow the pull-request
checklist.

[1]: https://github.com/aws-samples/aws-cdk-intro-workshop/blob/master/CONTRIBUTING.md
-->
As per https://cdkworkshop.com/30-python/70-advanced-topics/200-pipelines/1000-setting-up.html, keeping below line of code inside 'pipeline_stack.py' fails while doing 'cdk synth' and also 'npx cdk deploy' in then next 2000-create-repo.html page.

Fixes # <!-- Please create a new issue if none exists yet -->
Removed "from pipeline_stage import WorkshopPipelineStage" in order to succeed for cdk synth and cdk deploy.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
